### PR TITLE
Accept all api parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+### 0.2.1 Unreleased
+
+* [TT-3441] - Allow the additional "print-receipt" and "checkin" quicktravel parameters
+
 ### 0.2.0
 
 * [TT-3410] - Allowing passing the CSRF Token

--- a/lib/quicktravelApi.js
+++ b/lib/quicktravelApi.js
@@ -9,11 +9,9 @@ class QuickTravelApi {
     const body = {
       issued_ticket_ids: issuedTicketIds,
     };
-    if (opts.authenticity_token) {
-      body.authenticity_token = opts.authenticity_token;
-    }
     const url = `${this.host}/api/bookings/${bookingId}/issued_tickets/void`;
-    return post(url, JSON.stringify(body), { compress: false });
+    const data = JSON.stringify(Object.assign({}, body, opts));
+    return post(url, data, { compress: false });
   }
 
   reprintTickets(bookingId, issuedTicketIds, opts = {}) {
@@ -21,11 +19,9 @@ class QuickTravelApi {
       issued_ticket_ids: issuedTicketIds,
       print_server_type: 'quickets',
     };
-    if (opts.authenticity_token) {
-      body.authenticity_token = opts.authenticity_token;
-    }
+    const data = JSON.stringify(Object.assign({}, body, opts));
     const url = `${this.host}/api/bookings/${bookingId}/issued_tickets/reprint`;
-    return post(url, JSON.stringify(body), { compress: false });
+    return post(url, data , { compress: false });
   }
 
   issueAndPrint(bookingId, reservationIds, opts = {}) {
@@ -33,11 +29,9 @@ class QuickTravelApi {
       reservation_ids: reservationIds,
       print_server_type: 'quickets',
     };
-    if (opts.authenticity_token) {
-      body.authenticity_token = opts.authenticity_token;
-    }
+    const data = JSON.stringify(Object.assign({}, body, opts));
     const url = `${this.host}/api/bookings/${bookingId}/issued_tickets/issue_and_print`;
-    return post(url, JSON.stringify(body), { compress: false });
+    return post(url, data, { compress: false });
   }
 }
 


### PR DESCRIPTION
### Why  
Quicktravel passes through additional form parameters, so the JS will now pass them to QT.

### Test  
Ensure check-in and print receipt works from the issued tickets form  