### PR TITLE
Tt 3604 use isomorphic fetch

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+### 0.2.2
+
+* [TT-3604] - Use isomorphic-fetch rather than node-fetch
+
 ### 0.2.1
 
 * [TT-3441] - Allow the additional "print-receipt" and "checkin" quicktravel parameters

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+require('isomorphic-fetch');
 
 function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "homepage": "https://github.com/sealink/printers_qt#readme",
   "dependencies": {
-    "node-fetch": "^1.7.3",
+    "isomorphic-fetch": "^2.2.1",
     "regenerator-runtime": "^0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Why 
In the browser want to use the native window.fetch, in tests we use the node-fetch  

### Test
Ensure works in quicktravel  
