### PR TITLE
Tt 3615 fix cookie send

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+### Unreleased
+
+* [TT-3615] - Send session cookie 
+
+
 ### 0.2.2
 
 * [TT-3604] - Use isomorphic-fetch rather than node-fetch

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 ### Unreleased
 
-* [TT-3615] - Send session cookie 
-
+* [TT-3615] - Send session cookie
 
 ### 0.2.2
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -14,12 +14,13 @@ function parseJSON(response) {
 }
 
 export function get(url) {
-  return fetch(url).then(checkStatus).then(parseJSON);
+  return fetch(url, { credentials: 'same-origin' }).then(checkStatus).then(parseJSON);
 }
 
 export function post(url, body, options = {}) {
   const fetchOptions = {
     method: 'POST',
+    credentials: 'same-origin',
     headers: {
       'Content-Type': 'application/json',
     },


### PR DESCRIPTION
### Why  
Isomorphic fetch does not send cookies by default, this means QT will not be authenticated  

### Test  
Issue and print from within Quicktravel  