### PR TITLE
Tt 4615 support for configurable print server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+### Unreleased
+
+* [TT-4615] - Support configurable print server type
+
 ### 1.0.0
 
 * [TT-4538] - Support CORS in Quicktravel

--- a/lib/printService.js
+++ b/lib/printService.js
@@ -8,6 +8,7 @@ class PrintService {
     this.quicktravel_url = quicktravel.host;
     this.config_url = config.host;
     this.csrfToken = quicktravel.csrfToken;
+    this.qt_print_server_type = config.qt_print_server_type;
   }
 
   async printTickets(printGroupId, tickets) {
@@ -30,24 +31,24 @@ class PrintService {
   }
 
   async printReservations(printGroupId, bookingId, reservationIds, opts = {}) {
-    const tickets = await new QuickTravelApi(this.quicktravel_url, this.csrfToken)
+    const tickets = await new QuickTravelApi(this.quicktravel_url, this.csrfToken, this.qt_print_server_type)
       .issueAndPrint(bookingId, reservationIds, opts);
     return this.printTickets(printGroupId, tickets);
   }
 
   async reprintTickets(printGroupId, bookingId, issuedTicketIds, opts = {}) {
-    const tickets = await new QuickTravelApi(this.quicktravel_url, this.csrfToken)
+    const tickets = await new QuickTravelApi(this.quicktravel_url, this.csrfToken, this.qt_print_server_type)
       .reprintTickets(bookingId, issuedTicketIds, opts);
     return this.printTickets(printGroupId, tickets);
   }
 
   async voidTickets(bookingId, issuedTicketIds, opts = {}) {
-    return new QuickTravelApi(this.quicktravel_url, this.csrfToken)
+    return new QuickTravelApi(this.quicktravel_url, this.csrfToken, this.qt_print_server_type)
                 .voidTickets(bookingId, issuedTicketIds, opts);
   }
 
   async printReceipt(printGroupId, bookingId, opts = {}) {
-    const tickets = await new QuickTravelApi(this.quicktravel_url, this.csrfToken)
+    const tickets = await new QuickTravelApi(this.quicktravel_url, this.csrfToken, this.qt_print_server_type)
                 .printReceipt(bookingId, opts);
     return this.printTickets(printGroupId, tickets)
   }

--- a/lib/quicktravelApi.js
+++ b/lib/quicktravelApi.js
@@ -1,9 +1,10 @@
 import { request } from './api';
 
 class QuickTravelApi {
-  constructor(host, csrfToken) {
+  constructor(host, csrfToken, print_server_type = "") {
     this.host = host;
     this.csrfToken = csrfToken;
+    this.print_server_type = print_server_type || 'quickets';
   }
 
   makeRequest(body, opts = {}) {
@@ -30,7 +31,7 @@ class QuickTravelApi {
   reprintTickets(bookingId, issuedTicketIds, opts = {}) {
     const body = {
       issued_ticket_ids: issuedTicketIds,
-      print_server_type: 'quickets',
+      print_server_type: this.print_server_type,
     };
     const url = `${this.host}/api/bookings/${bookingId}/issued_tickets/reprint`;
     return request(url, this.makeRequest(body, opts));
@@ -39,7 +40,7 @@ class QuickTravelApi {
   printReceipt(bookingId, opts = {}) {
     const body = {
       print_receipt: true,
-      print_server_type: 'quickets',
+      print_server_type: this.print_server_type,
     };
     const url = `${this.host}/api/bookings/${bookingId}/issued_tickets/reprint`;
     return request(url, this.makeRequest(body, opts));
@@ -48,7 +49,7 @@ class QuickTravelApi {
   issueAndPrint(bookingId, reservationIds, opts = {}) {
     const body = {
       reservation_ids: reservationIds,
-      print_server_type: 'quickets',
+      print_server_type: this.print_server_type,
     };
     const url = `${this.host}/api/bookings/${bookingId}/issued_tickets/issue_and_print`;
     return request(url, this.makeRequest(body, opts));

--- a/test/printServiceTest.js
+++ b/test/printServiceTest.js
@@ -12,6 +12,19 @@ const config = {
   },
 };
 
+
+describe('configuration', () => {
+  it('should have configurable print_server_type', (done) => {
+    const printService = new PrintService(config);
+    expect(printService.qt_print_server_type).to.not.exist;
+
+    const printService2 = new PrintService({ quicktravel: config.quicktravel, config: { host: config.config.host, qt_print_server_type: 'crickets' } });
+    expect(printService2.qt_print_server_type).to.equal('crickets');
+
+    done();
+  });
+});
+
 describe('voidTickets', () => {
   beforeEach(() => {
     nock(config.quicktravel.host, { reqHeaders: { 'x-csrf-Token': '123' } })

--- a/test/quickTravelApiTest.js
+++ b/test/quickTravelApiTest.js
@@ -132,3 +132,17 @@ describe('void', () => {
     });
   });
 });
+
+
+describe('defaults and config', () => {
+  it('should have configurable print_server_type', (done) => {
+    const api = new QuickTravelApi(host);
+    expect(api.print_server_type).to.equal('quickets');
+
+    const api2 = new QuickTravelApi(host, 'token', 'crickets');
+    expect(api2.print_server_type).to.equal('crickets');
+
+    done();
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2050,6 +2050,13 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
+isomorphic-fetch@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -2452,7 +2459,7 @@ nock@^9.1.3:
     qs "^6.5.1"
     semver "^5.3.0"
 
-node-fetch@^1.7.3:
+node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
@@ -3437,6 +3444,10 @@ weak@^1.0.1:
   dependencies:
     bindings "^1.2.1"
     nan "^2.0.5"
+
+whatwg-fetch@>=0.10.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
WHY
Previously the the 'quickets' type was hardcoded.  Need to be able to change it so that the QuickTravleApi can request other print server types.

HOW
`print_server_type` is passed in a configuration parameter for both the `PrintServiceApi` and `QuickTravleApi`