### PR TITLE
TT 5444 add issued tickets barcodes endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * [TT-5422] - Add validate endpoint
+* [TT-5444] - Add issued_tickets/barcodes endpoint
 
 ### 1.2.1
 

--- a/lib/printService.js
+++ b/lib/printService.js
@@ -49,6 +49,10 @@ class PrintService {
     return this.createQuickTravelApi().issueTickets(bookingId, reservationIds, opts);
   }
 
+  async issuedTicket(ticketIdentifier, opts = {}) {
+    return this.createQuickTravelApi().issuedTicket(ticketIdentifier, opts);
+  }
+
   async reprintTickets(printGroupId, bookingId, issuedTicketIds, opts = {}) {
     const tickets = await this.createQuickTravelApi().reprintTickets(bookingId, issuedTicketIds, opts);
     return this.printTickets(printGroupId, tickets);

--- a/lib/quicktravelApi.js
+++ b/lib/quicktravelApi.js
@@ -1,4 +1,4 @@
-import { request } from './api';
+import { request, get } from './api';
 import { QUICKETS_SERVER_TYPE, ALBERT_SERVER_TYPE } from './constants';
 
 class QuickTravelApi {
@@ -66,13 +66,18 @@ class QuickTravelApi {
     return request(url, this.makeRequest(body, opts));
   }
 
-  validateTicket(ticket_identifier, opts = {}) {
+  validateTicket(ticketIdentifier, opts = {}) {
     const body = {
-      identifier: ticket_identifier
+      identifier: ticketIdentifier
     };
 
     const url = `${this.host}/api/issued_tickets/validate`;
     return request(url, this.makeRequest(body, opts));
+  }
+
+  issuedTicket(ticketIdentifier, opts = {}) {
+    const url = `${this.host}/api/issued_tickets/barcodes/${ticketIdentifier}`;
+    return get(url);
   }
 }
 

--- a/test/quickTravelApiTest.js
+++ b/test/quickTravelApiTest.js
@@ -223,6 +223,42 @@ describe('validate', () => {
   });
 });
 
+describe('issued_ticket', () => {
+  beforeEach(() => {
+    nock(host)
+      .get('/api/issued_tickets/barcodes/12345')
+      .reply(200, { ticket: 'TICKET GOES HERE' });
+
+    nock(host)
+      .get('/api/issued_tickets/barcodes/54321')
+      .reply(404, { error: 'ERROR GOES HERE' });
+  });
+
+  it('should find the ticket', (done) => {
+    const identifier = 12345;
+
+    new QuickTravelApi(host).issuedTicket(identifier).then((response) => {
+      expect(response).to.deep.equal( { ticket: 'TICKET GOES HERE' });
+      done();
+    });
+  });
+
+  it('should return an error if the ticket cant be found', (done) => {
+    const identifier = 54321;
+
+    new QuickTravelApi(host).issuedTicket(identifier)
+    .then((response) => {
+      fail('Should never be called')
+      done();
+    })
+    .catch((err) => {
+      expect(err.response.status).to.eq(404);
+      done();
+    });
+  });
+});
+
+
 
 describe('defaults and config', () => {
   it('should have configurable print_server_type', (done) => {


### PR DESCRIPTION
WHY
Need to expose issued_tickets/barcodes endpoint from QuickTravel

HOW
Mocha Tests