### PR TITLE
Tt 5645 Specific gets for qt

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+### Unreleased
+
+* [TT-5645] - Use "include" credentials only on QT GET requests.
+
 ### 1.4.0
 
 * [TT-5645] - Change credentials to "include" for GET requests

--- a/lib/api.js
+++ b/lib/api.js
@@ -20,7 +20,7 @@ function parseJSON(response) {
 }
 
 export function get(url) {
-  return fetch(url, { credentials: "include" })
+  return fetch(url, { credentials: "same-origin" })
     .then(checkStatus)
     .then(parseJSON);
 }

--- a/lib/quicktravelApi.js
+++ b/lib/quicktravelApi.js
@@ -1,4 +1,4 @@
-import { request, get } from "./api";
+import { request } from "./api";
 import { QUICKETS_SERVER_TYPE, ALBERT_SERVER_TYPE } from "./constants";
 
 class QuickTravelApi {
@@ -6,6 +6,16 @@ class QuickTravelApi {
     this.host = host;
     this.csrfToken = csrfToken;
     this.printServerType = printServerType;
+  }
+
+  makeGetRequest() {
+    return {
+      method: "GET",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json"
+      }
+    };
   }
 
   makeRequest(body, opts = {}) {
@@ -79,7 +89,7 @@ class QuickTravelApi {
 
   issuedTicket(ticketIdentifier, opts = {}) {
     const url = `${this.host}/api/issued_tickets/barcodes/${ticketIdentifier}`;
-    return get(url);
+    return request(url, this.makeGetRequest());
   }
 }
 


### PR DESCRIPTION
### WHY

Because QuickPrint / PrintersQT have AccessControlAllowOrigins = * we cannot include cookies for requests to these domains 