### PR TITLE
TT-8859: reverse merging order in makeRequest and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* [TT-8859] - Reverse the order of merging body and opts params in the makeRequest
+
 ## 1.9.0
 
 * [TT-8847] - Convert non-array input issuedTicketIds in quicktravelApi to be array

--- a/lib/quicktravelApi.js
+++ b/lib/quicktravelApi.js
@@ -28,7 +28,7 @@ class QuickTravelApi {
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.bearerToken}`
       },
-      body: JSON.stringify(Object.assign({}, body, opts))
+      body: JSON.stringify(Object.assign({}, opts, body))
     };
   }
 

--- a/test/quickTravelApiTest.js
+++ b/test/quickTravelApiTest.js
@@ -63,6 +63,20 @@ describe("reprint", () => {
         done();
       });
   });
+
+  it("should not overwrite default params", done => {
+    const issuedTicketIds = [1, 2, 3];
+    const opts = { authenticity_token: "token",
+                   print_server_type: "not quickets",
+                   issued_ticket_ids: [1, 2] };
+
+    new QuickTravelApi(host)
+      .reprintTickets(bookingId, issuedTicketIds, opts)
+      .then(response => {
+        expect(response).to.deep.equal({ msg: "SuccessWithToken" });
+        done();
+      });
+  });
 });
 
 describe("issue", () => {
@@ -149,6 +163,19 @@ describe("issue_and_print", () => {
         done();
       });
   });
+
+  it("should not overwrite default params", done => {
+    const opts = { authenticity_token: "token",
+                   print_server_type: "not quickets",
+                   reservation_ids: [1, 2] };
+
+    new QuickTravelApi(host)
+      .issueAndPrint(bookingId, reservationIds, opts)
+      .then(response => {
+        expect(response).to.deep.equal({ msg: "SuccessWithToken" });
+        done();
+      });
+  });
 });
 
 describe("void", () => {
@@ -162,6 +189,13 @@ describe("void", () => {
     nock(host)
       .post("/api/bookings/1/issued_tickets/void", {
         issued_ticket_ids: [1, 2, 3],
+        authenticity_token: "token"
+      })
+      .reply(204);
+
+    nock(host)
+      .post("/api/bookings/1/issued_tickets/void", {
+        issued_ticket_ids: [1],
         authenticity_token: "token"
       })
       .reply(204);
@@ -182,6 +216,18 @@ describe("void", () => {
     const issuedTicketIds = [1, 2, 3];
     const opts = { authenticity_token: "token" };
 
+    new QuickTravelApi(host)
+      .voidTickets(bookingId, issuedTicketIds, opts)
+      .then(response => {
+        expect(response).to.deep.equal({});
+        done();
+      });
+  });
+
+  it("should not overwrite default params", done => {
+    const issuedTicketIds = 1;
+    const opts = { authenticity_token: "token",
+                   issued_ticket_ids: [1, 2] };
     new QuickTravelApi(host)
       .voidTickets(bookingId, issuedTicketIds, opts)
       .then(response => {


### PR DESCRIPTION
### WHY
Avoid opts parameters overriding the parameters that have already been set in the api