### PR TITLE
TT-9025: expose issued_tickets board endpoint in printService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* [TT-9025] - Expose issued_tickets board endpoint from qt
+
 ## 1.10.0
 
 * [TT-8859] - Reverse the order of merging body and opts params in the makeRequest

--- a/lib/printService.js
+++ b/lib/printService.js
@@ -104,6 +104,11 @@ class PrintService {
     );
     return this.printTickets(printGroupId, tickets);
   }
+
+  async boardTickets(tickets) {
+    const serverScans = await this.createQuickTravelApi().wrapTickets(tickets);
+    return this.createQuickTravelApi().boardServerScans(serverScans);
+  }
 }
 
 export { PrintService as default };

--- a/lib/quicktravelApi.js
+++ b/lib/quicktravelApi.js
@@ -1,5 +1,6 @@
 import { request } from "./api";
 import { QUICKETS_SERVER_TYPE, ALBERT_SERVER_TYPE } from "./constants";
+import { v4 as uuidv4 } from 'uuid';
 
 class QuickTravelApi {
   constructor(host, bearerToken, printServerType = QUICKETS_SERVER_TYPE) {
@@ -91,6 +92,17 @@ class QuickTravelApi {
 
   convertToArray(input) {
     return Array.isArray(input) ? input : Array.of(input);
+  }
+
+  wrapTickets(tickets) {
+    return tickets.map(ticket => {
+      return { barcode: ticket, id: uuidv4()}
+    })
+  }
+
+  boardServerScans(serverScans) {
+    const url = `${this.host}/api/issued_tickets/board`;
+    return request(url, this.makeRequest(serverScans));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
   "homepage": "https://github.com/sealink/printers_qt#readme",
   "dependencies": {
     "isomorphic-fetch": "^3.0.0",
-    "regenerator-runtime": "^0.13.2"
+    "regenerator-runtime": "^0.13.2",
+    "sinon": "^9.2.4",
+    "uuid": "^3.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",

--- a/test/fixture/sampleBarcodes.js
+++ b/test/fixture/sampleBarcodes.js
@@ -1,0 +1,168 @@
+const CONSUMER_SPLIT_BARCODE = {
+    "id": 9,
+    "format": 0,
+    "reference": "22222K",
+    "reservation": {
+        "id": 3,
+        "booking_id": 12,
+        "trip_id": 1,
+        "route_id": null,
+        "service_id": null,
+        "departure_time": null,
+        "departure_date": "2017-11-15"
+    },
+    "resource": {
+        "id": 11,
+        "name": "Rottnest Island Gift Voucher - Different Day Return"
+    },
+    "vehicles": [
+        {
+        "id": 257194,
+        "type": {
+            "id": 10,
+            "name": "Luggage  (no larger than 800mm x 500mm x 400mm)"
+        },
+        "length": "1.0",
+        "width": null,
+        "height": "0.1",
+        "details": null,
+        "cargo": null,
+        "registration": null
+        }
+    ],
+    "passengers": [
+        {
+        "id": 16,
+        "name": "",
+        "type": {
+            "id": 1,
+            "name": "Adult"
+        }
+        }
+    ],
+    "requires_review": false,
+    "todo_items": [
+        "Item 1",
+        "Item 2"
+    ]
+};
+        
+const RESERVATION_BARCODE = {
+    "id": 172931,
+    "format": 1,
+    "reference": "229JGQ",
+    "resource": {
+        "id": 2,
+        "name": "Rottnest Island"
+    },
+    "reservation": {
+        "id": 172931,
+        "booking_id": 75688,
+        "trip_id": 35,
+        "route_id": 1,
+        "service_id": 7673,
+        "departure_time": "0910",
+        "departure_date": "2018-04-17"
+    },
+    "passenger_first_name": "Homer Simpson",
+    "passengers": {
+        "Ad": 2,
+        "Ch": 3
+    },
+    "vehicles": {
+        "Lugg": 2
+    },
+    "requires_review": false,
+    "todo_items": [
+        "Item 1", "Item 2"
+    ]
+};
+
+const CONSUMER_SPLIT_SCAN = {
+    "barcode": { 
+        "id": 9,
+        "format": 0,
+        "reference": "22222K",
+        "reservation": {
+            "id": 3,
+            "booking_id": 12,
+            "trip_id": 1,
+            "route_id": null,
+            "service_id": null,
+            "departure_time": null,
+            "departure_date": "2017-11-15"
+        },
+        "resource": {
+            "id": 11,
+            "name": "Rottnest Island Gift Voucher - Different Day Return"
+        },
+        "vehicles": [
+            {
+            "id": 257194,
+            "type": {
+                "id": 10,
+                "name": "Luggage  (no larger than 800mm x 500mm x 400mm)"
+            },
+            "length": "1.0",
+            "width": null,
+            "height": "0.1",
+            "details": null,
+            "cargo": null,
+            "registration": null
+            }
+        ],
+        "passengers": [
+            {
+            "id": 16,
+            "name": "",
+            "type": {
+                "id": 1,
+                "name": "Adult"
+            }
+            }
+        ],
+        "requires_review": false,
+        "todo_items": [
+            "Item 1",
+            "Item 2"
+        ]
+    },
+    "id": '1'
+};
+        
+const RESERVATION_SCAN = {
+    "barcode": {
+        "id": 172931,
+        "format": 1,
+        "reference": "229JGQ",
+        "resource": {
+            "id": 2,
+            "name": "Rottnest Island"
+        },
+        "reservation": {
+            "id": 172931,
+            "booking_id": 75688,
+            "trip_id": 35,
+            "route_id": 1,
+            "service_id": 7673,
+            "departure_time": "0910",
+            "departure_date": "2018-04-17"
+        },
+        "passenger_first_name": "Homer Simpson",
+        "passengers": {
+            "Ad": 2,
+            "Ch": 3
+        },
+        "vehicles": {
+            "Lugg": 2
+        },
+        "requires_review": false,
+        "todo_items": [
+            "Item 1", "Item 2"
+        ]
+    },
+    "id": '1'
+};
+
+module.exports = { CONSUMER_SPLIT_BARCODE, RESERVATION_BARCODE,
+                   CONSUMER_SPLIT_SCAN, RESERVATION_SCAN };

--- a/test/printServiceTest.js
+++ b/test/printServiceTest.js
@@ -5,6 +5,7 @@ const {
   QUICKETS_SERVER_TYPE,
   ALBERT_SERVER_TYPE
 } = require("../dist/printers_qt");
+const { QuickTravelApi } = require("../dist/printers_qt");
 
 const config = {
   quicktravel: {
@@ -537,5 +538,22 @@ describe("printReservations", () => {
         expect(response).to.eq(false);
         done();
       });
+  });
+});
+
+describe("boardTickets", () => {
+  beforeEach(() => {
+    const response = [{ id: '1', status: 200, diff: [] }];
+    nock(config.quicktravel.host)
+      .post("/api/issued_tickets/board")
+      .reply(200, response);
+  });
+
+  it("should call wrapTickets and boardServerScans from quicktravelApi", done => {
+    const printService = new PrintService(config);
+    printService.boardTickets([{ id: '1'}]).then(response => {
+      expect(response).to.deep.equal([{ id: '1', status: 200, diff: [] }]);
+      done();
+    });
   });
 });


### PR DESCRIPTION
### WHY
Printers QT needs to expose the QT/api/issued_tickets/board endpoint

### DETAILS
Add a method boardTickets in printService to receive an array of TicketJSON,
and return a promise of the results from Issued_tickets/board in quicktravel