### PR TITLE
Tt 9187 fix regenerator import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.2 Unreleased
+
+- [TT-9187] - Fix package when imported with webpack 5
+
 ## 1.11.1
 
 - [TT-9181] - Fix api call to issued_tickets board

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import 'regenerator-runtime/runtime';
+import 'regenerator-runtime/runtime.js';
 
 import PrintService from './printService';
 import ConfigApi from './configApi';


### PR DESCRIPTION
### WHY

Importing with webpack 5 you get the following error:

```ERROR in ./node_modules/@sealink/printers_qt/dist/printers_qt.mjs 1:0-37
Module not found: Error: Can't resolve 'regenerator-runtime/runtime' in '/home/mortlock/src/quicktravel/node_modules/@sealink/printers_qt/dist'
Did you mean 'runtime.js'?
BREAKING CHANGE: The request 'regenerator-runtime/runtime' failed to resolve only because it was resolved as fully specified
(probably because the origin is a '.mjs' file or a '.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
resolve 'regenerator-runtime/runtime' in '/home/mortlock/src/quicktravel/node_modules/@sealink/printers_qt/dist'
```

You fix this by providing the extesion