### PR TITLE
Tt 9512 allow 422 to return parsed object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - [TT-9454] - Update to Jest 27
+- [TT-9512] - Allow 422 to return json response object from QT
 
 ## 1.11.2
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -5,6 +5,7 @@ function checkStatus(response) {
     return response.json().then((json) => {
       const error = new Error(json.error);
       error.response = response;
+      error.json = json
       throw error;
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3817,9 +3817,9 @@
       "dev": true
     },
     "node_modules/handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.5",
@@ -10695,9 +10695,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",

--- a/test/quickTravelApi.test.js
+++ b/test/quickTravelApi.test.js
@@ -261,7 +261,7 @@ describe('validate', () => {
       .post('/api/issued_tickets/validate', {
         identifier: 321,
       })
-      .reply(422, { error: 'ERROR GOES HERE' });
+      .reply(422, { error: 'ERROR GOES HERE', staff_can_override: true });
   });
 
   it('should validate the ticket', (done) => {
@@ -284,6 +284,7 @@ describe('validate', () => {
       })
       .catch((err) => {
         expect(err.response.status).toEqual(422);
+        expect(err.json.staff_can_override).toEqual(true);
         done();
       });
   });


### PR DESCRIPTION
### WHY

In the case of a 422 response we might want to pass additional details to the client, currently we have to reparse this information in the client side (from the response object) so this makes life a little easier.