### PR TITLE
OPS-213 GHActions: Update JS projects to include Node 16

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: ['10', '12', '14']
+        node: ['12', '14', '16']
     name: Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- [OPS-213] GHActions: add Node 16 and remove None 10
+
 ## 1.12.0
 
 - [TT-9454] - Update to Jest 27


### PR DESCRIPTION
**Why:**
Add Node 16 and remove Node 10 in Github Action.

**How To Test:**
See the Action succeeded.