### PR TITLE
[TF-902] Fix build output path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- [TF-902] Fix build output path
+
 ## 1.14.0
 
 - [PLAT-1173] Add node 18 support

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -23,13 +23,13 @@ export default {
   external: ['regenerator-runtime/runtime'],
   output: [
     {
-      file: '../dist/printers_qt.js',
+      file: './dist/printers_qt.js',
       format: 'cjs',
       name: 'printers-qt',
       sourcemap: true,
     },
     {
-      file: '../dist/printers_qt.mjs',
+      file: './dist/printers_qt.mjs',
       format: 'es',
       sourcemap: true,
     },


### PR DESCRIPTION
## WHY

After upgrade `@sealink/printers_qt` from `1.13.0` to `1.14.0`, I got `Module not found: Error: Can't resolve '@sealink/printers_qt' in 'xxx'` issue.

After check the node module, I found there is no `/dist` folder

## WHAT

Fix build output path

## TEST

Print ticket in QT